### PR TITLE
Add support for deleting queues after flushing them

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def rabbitmq_broker():
     broker.emit_after("process_boot")
     dramatiq.set_broker(broker)
     yield broker
-    broker.flush_all()
+    broker.flush_all(delete_queue=True)
     broker.close()
 
 


### PR DESCRIPTION
In an environment where we're trying to reset a queue by flushing it (e.g. tests), it can be desirable to also have the ability for the queue to be deleted. For example, if you'd like to create a new queue with different parameters, but the same name.