### PR TITLE
Add support for Quorum Queues to RabbitMQ Broker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ extra_dependencies["dev"] = extra_dependencies["all"] + [
     "pytest",
     "pytest-benchmark[histogram]",
     "pytest-cov",
+    "requests",
     "tox",
 ]
 


### PR DESCRIPTION
This PR adds support for declaring queues as [quorum queues](https://www.rabbitmq.com/quorum-queues.html). Quorum queues are the new standard for persistent queues in RabbitMQ. Rather than adding a lot more complexity to management of queues, I've opted to have quorum queues a broker level setting. Either all queues are expected to be quorum queues or none of them are (for the instantiated broker). Unfortunately, there's no built-in way of switching a classic mirrored queue over to being a quorum queue. Rather than forcing an opinion on users, it's left up to the users.

For the purposes of Dramatiq, the major feature that is supported by the RabbitMQ broker, but [not by quorum queues](https://www.rabbitmq.com/quorum-queues.html#feature-matrix) is priorities. I've added an instantiation check to the RabbitMQ broker that raises an exception if it's passed both a `max_priority` & enables `quorum_queues`. I've chosen not to add any extra logic to messages that set a priority (you can imagine we silently swallow the message priority instead of erroring as would currently happen).

**Testing**

To facilitate testing if the queue is in fact a quorum queue, I've added the requests library and send an API request over to RabbitMQ directly. The alternative is more magic of declaring queues with the expected parameters that feels like it's breaking through too many layers of abstraction for my own comfort. I'm open to switching back to that approach to avoid adding the extra test dependency.