### PR TITLE
Ensure only canonical are added to RabbitmqBroker.queues

### DIFF
--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -26,7 +26,7 @@ from threading import Event, local
 import pika
 
 from ..broker import Broker, Consumer, MessageProxy
-from ..common import current_millis, dq_name, xq_name
+from ..common import current_millis, dq_name, q_name, xq_name
 from ..errors import ConnectionClosed, DecodeError, QueueJoinTimeout
 from ..logging import get_logger
 from ..message import Message, get_encoder
@@ -232,7 +232,7 @@ class RabbitmqBroker(Broker):
           ConnectionClosed: When ensure=True if the underlying channel
             or connection fails.
         """
-        if queue_name not in self.queues:
+        if q_name(queue_name) not in self.queues:
             self.emit_before("declare_queue", queue_name)
             self.queues.add(queue_name)
             self.queues_pending.add(queue_name)

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -492,3 +492,14 @@ def test_rabbitmq_messages_that_failed_to_decode_are_rejected(rabbitmq_broker, r
         assert xq_count == 1
     finally:
         dramatiq.set_encoder(old_encoder)
+
+
+def test_rabbitmq_queues_only_contains_canonical_name(rabbitmq_broker, rabbitmq_worker):
+    assert len(rabbitmq_broker.queues) == 0
+
+    @dramatiq.actor
+    def put():
+        pass
+
+    assert len(rabbitmq_broker.queues) == 1
+    assert put.queue_name in rabbitmq_broker.queues


### PR DESCRIPTION
When a worker is started, it'll eventually start two consumers: one for reading off the queue and another for reading off the delayed queue. When it starts consuming off the delayed queue, it calls `RabbitmqBroker#consume('queue_name.DQ')`. In tern, 'queue_name.DQ' goes through the declare queue initialization which results in its name being added to the `queues` set. This becomes an issue as later on in commands such as flush, assumptions are made that only the canonical queue name is present.